### PR TITLE
Rafactor Docker build and release workflow

### DIFF
--- a/.github/workflows/docker-hub-image.yml
+++ b/.github/workflows/docker-hub-image.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   fetch_release:
     runs-on: ubuntu-latest
+    outputs:
+      release_changed: ${{ env.release_changed }}
+      tdm_release_tag: ${{ env.tdm_release_tag }}
+      calver_tag: ${{ env.calver_tag }}
 
     steps:
       - name: Checkout Repository
@@ -16,10 +20,8 @@ jobs:
       - name: Fetch Latest TDM Release
         id: fetch_tdm_release
         run: |
-          # Fetch all releases from the GitHub API
           ALL_RELEASES=$(curl -s "https://api.github.com/repos/DevilXD/TwitchDropsMiner/releases")
           
-          # Filter for prerelease releases and select the desired asset
           RELEASE_DATA=$(echo "$ALL_RELEASES" | jq -r '
             .[] 
             | select(.prerelease) 
@@ -28,11 +30,13 @@ jobs:
             | .asset.updated_at + " " + .tag
           ' | head -n 1)
           
-          # Extract the asset updated_at and release tag name
           ASSET_UPDATED_AT=$(echo "$RELEASE_DATA" | cut -d' ' -f1)
           echo "Latest TDM Asset updated_at: $ASSET_UPDATED_AT"
+          
           echo "tdm_release_tag=$ASSET_UPDATED_AT" >> $GITHUB_ENV
           
+          CALVER_TAG=$(date -u -d "$ASSET_UPDATED_AT" +'%Y.%m.%d-%H.%M.%S')
+          echo "calver_tag=$CALVER_TAG" >> $GITHUB_ENV
 
       - name: Check If Release Tag Has Changed
         id: check_release
@@ -61,29 +65,41 @@ jobs:
           git add .release_tag
           git commit -m "Update release tag to ${{ env.tdm_release_tag }}"
           git push origin HEAD
-    outputs:
-      release_changed: ${{ env.release_changed }}
-      tdm_release_tag: ${{ env.tdm_release_tag }}
 
   build:
     runs-on: ubuntu-latest
     needs: fetch_release
+    if: needs.fetch_release.outputs.release_changed == 'true'
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Skip Build If Release Tag Unchanged
-        if: needs.fetch_release.outputs.release_changed == 'false'
-        run: |
-          echo "Release tag has not changed. Skipping actions."
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build If Release Tag Changes
-        if: needs.fetch_release.outputs.release_changed == 'true'
-        env:
-          DOCKER_HUB_NAME: ${{ secrets.DOCKER_HUB_NAME }}
-          DOCKER_HUB_KEY: ${{ secrets.DOCKER_HUB_KEY }}
-        run: |
-          docker login -u $DOCKER_HUB_NAME -p $DOCKER_HUB_KEY
-          docker build . --build-arg APP_VERSION_ARG=${{ needs.fetch_release.outputs.tdm_release_tag }} --pull --no-cache --tag gamerdachs/dockerized-twitch-drops-miner:latest
-          docker push gamerdachs/dockerized-twitch-drops-miner:latest
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_NAME }}
+          password: ${{ secrets.DOCKER_HUB_KEY }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: gamerdachs/dockerized-twitch-drops-miner
+          tags: |
+            type=raw,value=latest
+            type=sha
+            type=raw,value=${{ needs.fetch_release.outputs.calver_tag }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION_ARG=${{ needs.fetch_release.outputs.tdm_release_tag }}

--- a/.release_tag
+++ b/.release_tag
@@ -1,1 +1,1 @@
-2026-03-31T15:05:28Z
+Change to trigger Workflow


### PR DESCRIPTION
- Docker Actions Integration: Replaced raw docker shell commands with the official docker/login-action, docker/setup-buildx-action, docker/metadata-action, and docker/build-push-action for a cleaner, more maintainable workflow
- Job-Level if Condition: Moved the release_changed check to the build job level. This entirely skips spinning up the build runner if there is no new release, saving GitHub Actions minutes
- CalVer with Time: Added a line in the fetch_release step to parse the asset's ISO 8601 updated_at timestamp (e.g., 2026-03-31T15:05:28Z) and reformat it into a CalVer + time format (e.g., 2026.03.31-15.05.28)
- Metadata Action: Configured the docker/metadata-action to apply both the latest tag and the dynamically generated CalVer tag